### PR TITLE
Typo in /wesf

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ This can especially be helpful for addon creators, server owners and people who 
 This can be helpful with testing how optimized the blocks are or if they would cause any issues in mass usage.
 
 ## Commands
-- `/wsef pos1` This command sets the location for position 1 for your paste/clear command.
-- `/wsef pos2` This command sets the location for position 2 for your paste/clear command.
-- `/wsef paste <Slimefun ID>` This command pastes the block you specified in the world with the position you chose. It has 1 argument that is the slimefun id. This can be any placeable Slimefun block or it's addons.
-- `/wsef clear <boolean>` This command clears the blocks you have selected with the position commands. When `true` it fires a blockbreakevent coming from a player. This is used to clear all the handlers. When `false` it just removes the block and the blockstorage data.
+- `/wesf pos1` This command sets the location for position 1 for your paste/clear command.
+- `/wesf pos2` This command sets the location for position 2 for your paste/clear command.
+- `/wesf paste <Slimefun ID>` This command pastes the block you specified in the world with the position you chose. It has 1 argument that is the slimefun id. This can be any placeable Slimefun block or it's addons.
+- `/wesf clear <boolean>` This command clears the blocks you have selected with the position commands. When `true` it fires a blockbreakevent coming from a player. This is used to clear all the handlers. When `false` it just removes the block and the blockstorage data.
 
 ## Download
 You can find the download of this addon in the [releases](https://github.com/Slimefun-Addon-Community/WorldEditSlimefun/releases/tag/latest) tab

--- a/src/main/java/dev/j3fftw/worldeditslimefun/commands/WorldEditSlimefunCommands.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/commands/WorldEditSlimefunCommands.java
@@ -24,7 +24,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 
-@CommandAlias("wsef|sfedit")
+@CommandAlias("wesf|sfedit")
 public class WorldEditSlimefunCommands extends BaseCommand {
 
     @Default


### PR DESCRIPTION
I assume "wesf" stands for "WorldEditSlimefun", so I fixed the typos in the commands, as well as the readme.