### PR TITLE
Fix missing config.yml in resources

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,1 @@
+auto-update: true


### PR DESCRIPTION
Latest build fails to load with following error: 
The embedded resource 'config.yml' cannot be found in plugins/WorldEditSlimefun.jar.
This is because there is no config.yml in resources. This PR adds a default config.yml to fix the error.