### PR TITLE
[Update] Add new Features & Fixes (see desc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This can especially be helpful for addon creators, server owners and people who 
 This can be helpful with testing how optimized the blocks are or if they would cause any issues in mass usage.
 
 ## Commands
+- `/wesf wand` This command gives a player the selection wand
 - `/wesf pos1` This command sets the location for position 1 for your paste/clear command.
 - `/wesf pos2` This command sets the location for position 2 for your paste/clear command.
 - `/wesf paste <Slimefun ID>` This command pastes the block you specified in the world with the position you chose. It has 1 argument that is the slimefun item id. This can be any placeable Slimefun or Slimefun Addon block.

--- a/README.md
+++ b/README.md
@@ -13,14 +13,22 @@ This can be helpful with testing how optimized the blocks are or if they would c
   - This command sets position 1.
 - `/wesf pos2` 
   - This command sets position 2.
-- `/wesf paste <slimefun_block> [energy] [inputs]` 
+- `/wesf paste <slimefun_block> [flags...]` 
   - This command pastes the block specified in the area selected.
-  - `<slimefun_block>` (required), a string id, it can be any slimefun or slimefun addon block
-  - `[energy]` (optional), a boolean, charges the pasted blocks to max integer so they can process pseudo-infinitely (if possible)
-  - `[inputs]` (optional), a string array, places these items in the blocks input slots (if possible)
+  - `<slimefun_block>`, a string id, it can be any slimefun or slimefun addon block
+  - `[energy]`, a boolean, charges the pasted blocks to max integer so they can process pseudo-infinitely (if possible)
+  - `[inputs]`, a string array, places these items in the blocks input slots (if possible)
+  - `[refill_inputs_task]`, a boolean, if the inputs should be refilled every slimefun tick (if possible)
+    - Uses the inputs provided by the `[inputs]` flag, if none are provided, the task is not scheduled
+    - Lasts for a default of 5 minutes, however can be overridden by the `[task_timeout]` flag
+    - If a block is broken it is removed from the task, if all blocks are broken, the task ends automatically
+  - `[void_outputs_task]`, a boolean, if the outputs should be voided every slimefun tick (if possible)
+    - Lasts for a default of 5 minutes, however can be overridden by the `[task_timeout]` flag
+    - If a block is broken it is removed from the task, if all blocks are broken, the task ends automatically
+  - `[task_timeout]`, a string (`30s` `5m` `1h`), the amount of time any tasks should run for (if possible)
 - `/wesf clear [call_event]`
   - This command clears the blocks you have selected with the position commands. 
-  - `[call_event]` (optional), a boolean, if a `BlockBreakEvent` should be used to trigger item handlers. (defaults to `false`)
+  - `[call_event]`, a boolean, if a `BlockBreakEvent` should be used to trigger item handlers. (defaults to `false`)
 
 ## Download
 You can find the download of this addon in on [Blob Builds](https://blob.build/project/WorldEditSlimefun).

--- a/README.md
+++ b/README.md
@@ -7,11 +7,20 @@ This can especially be helpful for addon creators, server owners and people who 
 This can be helpful with testing how optimized the blocks are or if they would cause any issues in mass usage.
 
 ## Commands
-- `/wesf wand` This command gives a player the selection wand
-- `/wesf pos1` This command sets the location for position 1 for your paste/clear command.
-- `/wesf pos2` This command sets the location for position 2 for your paste/clear command.
-- `/wesf paste <Slimefun ID>` This command pastes the block you specified in the world with the position you chose. It has 1 argument that is the slimefun item id. This can be any placeable Slimefun or Slimefun Addon block.
-- `/wesf clear <boolean>` This command clears the blocks you have selected with the position commands. When `true` it fires a blockbreakevent coming from a player. This is used to clear all the handlers. When `false` it just removes the block and the blockstorage data.
+- `/wesf wand` 
+  - This command gives a player the selection wand
+- `/wesf pos1`
+  - This command sets position 1 of your selection.
+- `/wesf pos2` 
+  - This command sets position 2 of your selection.
+- `/wesf paste <slimefun_block> <energy> <inputs>` 
+  - This command pastes the block specified in the area selected.
+  - `<slimefun_block>` (required), a string id, it can be any slimefun or slimefun addon block
+  - `<energy>` (optional), a boolean, charges the pasted blocks to max integer so they can process pseudo-infinitely (if possible)
+  - `<inputs>` (optional), a string array, places these items in the blocks input slots (if possible)
+- `/wesf clear <call_event>`
+  - This command clears the blocks you have selected with the position commands. 
+  - `<call_event>` (optional), a boolean, if a `BlockBreakEvent` should be used to trigger item handlers. (defaults to `false`)
 
 ## Download
 You can find the download of this addon in the [releases](https://github.com/Slimefun-Addon-Community/WorldEditSlimefun/releases/tag/latest) tab

--- a/README.md
+++ b/README.md
@@ -10,17 +10,17 @@ This can be helpful with testing how optimized the blocks are or if they would c
 - `/wesf wand` 
   - This command gives a player the selection wand
 - `/wesf pos1`
-  - This command sets position 1 of your selection.
+  - This command sets position 1.
 - `/wesf pos2` 
-  - This command sets position 2 of your selection.
-- `/wesf paste <slimefun_block> <energy> <inputs>` 
+  - This command sets position 2.
+- `/wesf paste <slimefun_block> [energy] [inputs]` 
   - This command pastes the block specified in the area selected.
   - `<slimefun_block>` (required), a string id, it can be any slimefun or slimefun addon block
-  - `<energy>` (optional), a boolean, charges the pasted blocks to max integer so they can process pseudo-infinitely (if possible)
-  - `<inputs>` (optional), a string array, places these items in the blocks input slots (if possible)
-- `/wesf clear <call_event>`
+  - `[energy]` (optional), a boolean, charges the pasted blocks to max integer so they can process pseudo-infinitely (if possible)
+  - `[inputs]` (optional), a string array, places these items in the blocks input slots (if possible)
+- `/wesf clear [call_event]`
   - This command clears the blocks you have selected with the position commands. 
-  - `<call_event>` (optional), a boolean, if a `BlockBreakEvent` should be used to trigger item handlers. (defaults to `false`)
+  - `[call_event]` (optional), a boolean, if a `BlockBreakEvent` should be used to trigger item handlers. (defaults to `false`)
 
 ## Download
 You can find the download of this addon in the [releases](https://github.com/Slimefun-Addon-Community/WorldEditSlimefun/releases/tag/latest) tab

--- a/pom.xml
+++ b/pom.xml
@@ -48,11 +48,11 @@
                         </relocation>
                         <relocation>
                             <pattern>co.aikar.commands</pattern>
-                            <shadedPattern>dev.j3fftw.worldeditslimefun.acf</shadedPattern> <!-- Replace this -->
+                            <shadedPattern>dev.j3fftw.worldeditslimefun.acf</shadedPattern>
                         </relocation>
                         <relocation>
                             <pattern>co.aikar.locales</pattern>
-                            <shadedPattern>dev.j3fftw.worldeditslimefun.locales</shadedPattern> <!-- Replace this -->
+                            <shadedPattern>dev.j3fftw.worldeditslimefun.locales</shadedPattern>
                         </relocation>
                     </relocations>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -26,25 +26,42 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.11.0</version>
                 <configuration>
                     <source>17</source>
                     <target>17</target>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
+                <version>3.4.1</version>
+                <configuration>
+                    <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+                    <relocations>
+                        <relocation>
+                            <pattern>org.bstats</pattern>
+                            <shadedPattern>dev.j3fftw.worldeditslimefun.bstats</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>co.aikar.commands</pattern>
+                            <shadedPattern>dev.j3fftw.worldeditslimefun.acf</shadedPattern> <!-- Replace this -->
+                        </relocation>
+                        <relocation>
+                            <pattern>co.aikar.locales</pattern>
+                            <shadedPattern>dev.j3fftw.worldeditslimefun.locales</shadedPattern> <!-- Replace this -->
+                        </relocation>
+                    </relocations>
+                </configuration>
                 <executions>
                     <execution>
                         <phase>package</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>
-                        <configuration>
-                            <createDependencyReducedPom>false</createDependencyReducedPom>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/src/main/java/dev/j3fftw/worldeditslimefun/WorldEditSlimefun.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/WorldEditSlimefun.java
@@ -2,6 +2,8 @@ package dev.j3fftw.worldeditslimefun;
 
 import co.aikar.commands.PaperCommandManager;
 import dev.j3fftw.worldeditslimefun.commands.WorldEditSlimefunCommands;
+import dev.j3fftw.worldeditslimefun.slimefun.Items;
+import dev.j3fftw.worldeditslimefun.slimefun.WandListener;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
@@ -9,12 +11,13 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.blocks.Unplaceabl
 import io.github.thebusybiscuit.slimefun4.libraries.dough.blocks.BlockPosition;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.updater.BlobBuildUpdater;
 import org.bstats.bukkit.Metrics;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -55,17 +58,37 @@ public final class WorldEditSlimefun extends JavaPlugin implements SlimefunAddon
             }
             return placeableItems;
         });
+
+        Items.init(this);
+        Bukkit.getPluginManager().registerEvents(new WandListener(), this);
     }
 
     @Override
     public void onDisable() {}
 
+    @Nonnull
+    public static String beautifyBlockPosition(@Nonnull BlockPosition position) {
+        return "%s, %s, %s (%s)".formatted(position.getX(), position.getY(), position.getZ(), position.getWorld().getName());
+    }
+
     public static void addPositionOne(@Nonnull Player player) {
-        STORED_POSITION_ONE.put(player.getUniqueId(), new BlockPosition(player.getLocation()));
+        addPositionOne(player, new BlockPosition(player.getLocation()));
+    }
+
+    @ParametersAreNonnullByDefault
+    public static void addPositionOne(Player player, BlockPosition position) {
+        STORED_POSITION_ONE.put(player.getUniqueId(), position);
+        player.sendMessage("Set position 1 to " + beautifyBlockPosition(position));
     }
 
     public static void addPositionTwo(@Nonnull Player player) {
-        STORED_POSITION_TWO.put(player.getUniqueId(), new BlockPosition(player.getLocation()));
+        addPositionTwo(player, new BlockPosition(player.getLocation()));
+    }
+
+    @ParametersAreNonnullByDefault
+    public static void addPositionTwo(Player player, BlockPosition position) {
+        STORED_POSITION_TWO.put(player.getUniqueId(), position);
+        player.sendMessage("Set position 2 to " + beautifyBlockPosition(position));
     }
 
     @Nullable
@@ -78,13 +101,13 @@ public final class WorldEditSlimefun extends JavaPlugin implements SlimefunAddon
         return STORED_POSITION_TWO.get(player.getUniqueId());
     }
 
-    @NotNull
+    @Nonnull
     @Override
     public JavaPlugin getJavaPlugin() {
         return this;
     }
 
-    @Nullable
+    @Nonnull
     @Override
     public String getBugTrackerURL() {
         return "https://github.com/Slimefun-Addon-Community/WorldEditSlimefun/issues";

--- a/src/main/java/dev/j3fftw/worldeditslimefun/WorldEditSlimefun.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/WorldEditSlimefun.java
@@ -14,8 +14,12 @@ import java.io.File;
 
 public final class WorldEditSlimefun extends JavaPlugin implements SlimefunAddon {
 
+    private static WorldEditSlimefun instance;
+
     @Override
     public void onEnable() {
+        instance = this;
+
         if (!new File(getDataFolder(), "config.yml").exists()) {
             saveDefaultConfig();
         }
@@ -44,5 +48,9 @@ public final class WorldEditSlimefun extends JavaPlugin implements SlimefunAddon
     @Override
     public String getBugTrackerURL() {
         return "https://github.com/Slimefun-Addon-Community/WorldEditSlimefun/issues";
+    }
+
+    public static WorldEditSlimefun getInstance() {
+        return instance;
     }
 }

--- a/src/main/java/dev/j3fftw/worldeditslimefun/WorldEditSlimefun.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/WorldEditSlimefun.java
@@ -1,37 +1,18 @@
 package dev.j3fftw.worldeditslimefun;
 
-import co.aikar.commands.PaperCommandManager;
 import dev.j3fftw.worldeditslimefun.commands.WorldEditSlimefunCommands;
 import dev.j3fftw.worldeditslimefun.slimefun.Items;
 import dev.j3fftw.worldeditslimefun.slimefun.WandListener;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
-import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
-import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
-import io.github.thebusybiscuit.slimefun4.implementation.items.blocks.UnplaceableBlock;
-import io.github.thebusybiscuit.slimefun4.libraries.dough.blocks.BlockPosition;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.updater.BlobBuildUpdater;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.Bukkit;
-import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.File;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
 
 public final class WorldEditSlimefun extends JavaPlugin implements SlimefunAddon {
-
-    @Nonnull
-    private static final Map<UUID, BlockPosition> STORED_POSITION_ONE = new HashMap<>();
-
-    @Nonnull
-    private static final Map<UUID, BlockPosition> STORED_POSITION_TWO = new HashMap<>();
 
     @Override
     public void onEnable() {
@@ -45,61 +26,13 @@ public final class WorldEditSlimefun extends JavaPlugin implements SlimefunAddon
 
         new Metrics(this, 20799);
 
-        PaperCommandManager paperCommandManager = new PaperCommandManager(this);
-        paperCommandManager.registerCommand(new WorldEditSlimefunCommands());
-        paperCommandManager.getCommandCompletions().registerCompletion("boolean", context -> List.of("true", "false"));
-        paperCommandManager.getCommandCompletions().registerCompletion("slimefun_items", context -> {
-            List<SlimefunItem> slimefunItems = Slimefun.getRegistry().getEnabledSlimefunItems();
-            List<String> placeableItems = new ArrayList<>();
-            for (SlimefunItem item : slimefunItems) {
-                if (!(item instanceof UnplaceableBlock) && item.getItem().getType().isBlock()) {
-                    placeableItems.add(item.getId());
-                }
-            }
-            return placeableItems;
-        });
-
         Items.init(this);
+        WorldEditSlimefunCommands.init(this);
         Bukkit.getPluginManager().registerEvents(new WandListener(), this);
     }
 
     @Override
     public void onDisable() {}
-
-    @Nonnull
-    public static String beautifyBlockPosition(@Nonnull BlockPosition position) {
-        return "%s, %s, %s (%s)".formatted(position.getX(), position.getY(), position.getZ(), position.getWorld().getName());
-    }
-
-    public static void addPositionOne(@Nonnull Player player) {
-        addPositionOne(player, new BlockPosition(player.getLocation()));
-    }
-
-    @ParametersAreNonnullByDefault
-    public static void addPositionOne(Player player, BlockPosition position) {
-        STORED_POSITION_ONE.put(player.getUniqueId(), position);
-        player.sendMessage("Set position 1 to " + beautifyBlockPosition(position));
-    }
-
-    public static void addPositionTwo(@Nonnull Player player) {
-        addPositionTwo(player, new BlockPosition(player.getLocation()));
-    }
-
-    @ParametersAreNonnullByDefault
-    public static void addPositionTwo(Player player, BlockPosition position) {
-        STORED_POSITION_TWO.put(player.getUniqueId(), position);
-        player.sendMessage("Set position 2 to " + beautifyBlockPosition(position));
-    }
-
-    @Nullable
-    public static BlockPosition getPositionOne(@Nonnull Player player) {
-        return STORED_POSITION_ONE.get(player.getUniqueId());
-    }
-
-    @Nullable
-    public static BlockPosition getPositionTwo(@Nonnull Player player) {
-        return STORED_POSITION_TWO.get(player.getUniqueId());
-    }
 
     @Nonnull
     @Override

--- a/src/main/java/dev/j3fftw/worldeditslimefun/commands/WorldEditSlimefunCommands.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/commands/WorldEditSlimefunCommands.java
@@ -22,6 +22,7 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.inventory.ItemStack;
 
 @CommandAlias("wesf|sfedit")
 public class WorldEditSlimefunCommands extends BaseCommand {
@@ -31,23 +32,28 @@ public class WorldEditSlimefunCommands extends BaseCommand {
         player.sendMessage(ChatColor.RED + "Please provide a valid subcommand.");
     }
 
+    @Subcommand("wand")
+    @CommandPermission("wesf.admin")
+    public void onWand(Player player) {
+        final ItemStack wand = SlimefunItem.getOptionalById("WEF_WAND").map(SlimefunItem::getItem).orElse(null);
+        if (wand == null) {
+            player.sendMessage(ChatColor.RED + "Wand not found!");
+            return;
+        }
+
+        player.getInventory().addItem(wand);
+    }
+
     @Subcommand("pos1")
     @CommandPermission("wesf.admin")
     public void onPos1(Player player) {
         WorldEditSlimefun.addPositionOne(player);
-        player.sendMessage("Set position 1 to " + beautifyBlockPosition(player));
     }
 
     @Subcommand("pos2")
     @CommandPermission("wesf.admin")
     public void onPos2(Player player) {
         WorldEditSlimefun.addPositionTwo(player);
-        player.sendMessage("Set position 2 to " + beautifyBlockPosition(player));
-    }
-
-    public String beautifyBlockPosition(Player player) {
-        final BlockPosition position = new BlockPosition(player.getLocation());
-        return "%s, %s, %s (%s)".formatted(position.getX(), position.getY(), position.getZ(), position.getWorld().getName());
     }
 
     @Subcommand("paste")

--- a/src/main/java/dev/j3fftw/worldeditslimefun/commands/WorldEditSlimefunCommands.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/commands/WorldEditSlimefunCommands.java
@@ -85,6 +85,8 @@ public class WorldEditSlimefunCommands extends BaseCommand {
     @Subcommand("wand")
     public void onWand(Player player) {
         ItemStack wand = SlimefunItem.getOptionalById("WESF_WAND").map(SlimefunItem::getItem).orElse(null);
+
+        // This should never be reached
         if (wand == null) {
             player.sendMessage(ChatColor.RED + "Wand not found!");
             return;

--- a/src/main/java/dev/j3fftw/worldeditslimefun/commands/WorldEditSlimefunCommands.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/commands/WorldEditSlimefunCommands.java
@@ -106,7 +106,7 @@ public class WorldEditSlimefunCommands extends BaseCommand {
             return;
         }
 
-        boolean charge = sfItem instanceof EnergyNetComponent component && component.isChargeable();
+        boolean charge = energy && sfItem instanceof EnergyNetComponent component && component.isChargeable();
         boolean fillItems = inputs != null && Slimefun.getRegistry().getMenuPresets().containsKey(sfId) && hasValidInputs(inputs);
 
         ItemStack item = sfItem.getItem();

--- a/src/main/java/dev/j3fftw/worldeditslimefun/commands/WorldEditSlimefunCommands.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/commands/WorldEditSlimefunCommands.java
@@ -140,7 +140,7 @@ public class WorldEditSlimefunCommands extends BaseCommand {
             });
 
             for (CommandFlag<?> flag : flags) {
-                flag.apply(sfItem, block);
+                flag.apply(flags, sfItem, block);
             }
         });
         long time = System.currentTimeMillis() - start;

--- a/src/main/java/dev/j3fftw/worldeditslimefun/commands/WorldEditSlimefunCommands.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/commands/WorldEditSlimefunCommands.java
@@ -52,8 +52,8 @@ public class WorldEditSlimefunCommands extends BaseCommand {
         completions.registerCompletion("slimefun_blocks", context -> Utils.SLIMEFUN_BLOCKS);
         completions.registerCompletion("slimefun_items", context -> Utils.SLIMEFUN_ITEMS);
         completions.registerCompletion("materials", context -> {
-            final List<String> inputs = new ArrayList<>();
-            final World world = context.getPlayer().getWorld();
+            List<String> inputs = new ArrayList<>();
+            World world = context.getPlayer().getWorld();
             for (Material material : Utils.MATERIALS.values()) {
                 if (material.isEnabledByFeature(world)) {
                     inputs.add(material.name());
@@ -125,8 +125,8 @@ public class WorldEditSlimefunCommands extends BaseCommand {
             }
 
             if (fillItems) {
-                final BlockMenu menu = BlockStorage.getInventory(block);
-                final int[] slots = menu.getPreset().getSlotsAccessedByItemTransport(ItemTransportFlow.INSERT);
+                BlockMenu menu = BlockStorage.getInventory(block);
+                int[] slots = menu.getPreset().getSlotsAccessedByItemTransport(ItemTransportFlow.INSERT);
                 for (ItemStack input : getInputs(inputs)) {
                     if (menu.pushItem(input, slots) != null) {
                         break;

--- a/src/main/java/dev/j3fftw/worldeditslimefun/commands/flags/CommandFlag.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/commands/flags/CommandFlag.java
@@ -1,0 +1,22 @@
+package dev.j3fftw.worldeditslimefun.commands.flags;
+
+import co.aikar.commands.BukkitCommandCompletionContext;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import org.bukkit.block.Block;
+
+import java.util.Collection;
+
+public abstract class CommandFlag<T> {
+    protected T value;
+
+    public CommandFlag<T> setValue(T value) {
+        this.value = value;
+        return this;
+    }
+
+    public abstract void apply(SlimefunItem sfItem, Block block);
+    public abstract boolean canApply(SlimefunItem sfItem);
+    public abstract Collection<String> getTabSuggestions(BukkitCommandCompletionContext context);
+
+    public abstract CommandFlag<T> ofValue(String value);
+}

--- a/src/main/java/dev/j3fftw/worldeditslimefun/commands/flags/CommandFlag.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/commands/flags/CommandFlag.java
@@ -5,6 +5,7 @@ import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import org.bukkit.block.Block;
 
 import java.util.Collection;
+import java.util.List;
 
 public abstract class CommandFlag<T> {
     protected T value;
@@ -14,7 +15,11 @@ public abstract class CommandFlag<T> {
         return this;
     }
 
-    public abstract void apply(SlimefunItem sfItem, Block block);
+    public T getValue() {
+        return value;
+    }
+
+    public abstract void apply(List<CommandFlag<?>> flags, SlimefunItem sfItem, Block block);
     public abstract boolean canApply(SlimefunItem sfItem);
     public abstract Collection<String> getTabSuggestions(BukkitCommandCompletionContext context);
 

--- a/src/main/java/dev/j3fftw/worldeditslimefun/commands/flags/CommandFlags.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/commands/flags/CommandFlags.java
@@ -1,0 +1,172 @@
+package dev.j3fftw.worldeditslimefun.commands.flags;
+
+import co.aikar.commands.BukkitCommandCompletionContext;
+import dev.j3fftw.worldeditslimefun.utils.Utils;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.core.attributes.EnergyNetComponent;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.items.CustomItemStack;
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
+import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
+import me.mrCookieSlime.Slimefun.api.item_transport.ItemTransportFlow;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public class CommandFlags {
+    public static final Map<String, CommandFlag<?>> FLAG_TYPES = Map.of(
+            "--energy", new EnergyFlag(),
+            "--inputs", new InputsFlag()
+    );
+
+    public static List<CommandFlag<?>> getFlags(List<String> args) {
+        List<CommandFlag<?>> flags = new ArrayList<>();
+        for (int i = 0; i < args.size(); i++) {
+            String arg = args.get(i);
+            if (FLAG_TYPES.containsKey(arg)) {
+                CommandFlag<?> flag = CommandFlags.getFlag(arg, args.get(i + 1));
+                if (flag != null) {
+                    flags.add(flag);
+                }
+            }
+        }
+        return flags;
+    }
+
+    public static CommandFlag<?> getFlag(String type, String value) {
+        CommandFlag<?> flag = FLAG_TYPES.get(type);
+        if (flag != null) {
+            return flag.ofValue(value);
+        }
+        return null;
+    }
+
+    public static class EnergyFlag extends CommandFlag<Boolean> {
+        @Override
+        public void apply(SlimefunItem sfItem, Block block) {
+            BlockStorage.addBlockInfo(block, "energy-charge", String.valueOf(Integer.MAX_VALUE), false);
+        }
+
+        @Override
+        public boolean canApply(SlimefunItem sfItem) {
+            return this.value && sfItem instanceof EnergyNetComponent component && component.isChargeable();
+        }
+
+        @Override
+        public Collection<String> getTabSuggestions(BukkitCommandCompletionContext context) {
+            return List.of("true", "false");
+        }
+
+        @Override
+        public EnergyFlag ofValue(String value) {
+            return (EnergyFlag) new EnergyFlag().setValue(Boolean.parseBoolean(value));
+        }
+    }
+
+    public static class InputsFlag extends CommandFlag<List<ItemStack>> {
+
+        @Override
+        public void apply(SlimefunItem sfItem, Block block) {
+            BlockMenu menu = BlockStorage.getInventory(block);
+            int[] slots = menu.getPreset().getSlotsAccessedByItemTransport(ItemTransportFlow.INSERT);
+            for (ItemStack input : this.value) {
+                if (menu.pushItem(input, slots) != null) {
+                    break;
+                }
+            }
+        }
+
+        @Override
+        public boolean canApply(SlimefunItem sfItem) {
+            return this.value != null && !this.value.isEmpty() && Slimefun.getRegistry().getMenuPresets().containsKey(sfItem.getId());
+        }
+
+        @Override
+        public Collection<String> getTabSuggestions(BukkitCommandCompletionContext context) {
+            String input = context.getInput();
+            if (input.isEmpty()) {
+                return List.of("[");
+            }
+
+            char lastChar = input.charAt(input.length() - 1);
+            if (lastChar == ']') {
+                return Collections.emptyList();
+            }
+
+            List<String> inputs = new ArrayList<>();
+            if (lastChar == ',') {
+                inputs.addAll(generateBaseInputs(input, context.getPlayer().getWorld()));
+            } else {
+                String current;
+                if (input.contains(",")) {
+                    current = input.substring(input.lastIndexOf(",") + 1);
+                } else {
+                    current = input.substring(input.indexOf('[') + 1);
+                }
+                current = current.toUpperCase(Locale.ROOT);
+
+                if (Utils.SLIMEFUN_ITEMS.contains(current) || Utils.MATERIALS.containsKey(current)) {
+                    inputs.add(input + "]");
+                    inputs.addAll(generateBaseInputs(input + ",", context.getPlayer().getWorld()));
+                    return inputs;
+                }
+
+                String base = input.substring(0, input.length() - current.length());
+                for (String slimefunItem : Utils.SLIMEFUN_ITEMS) {
+                    if (slimefunItem.startsWith(current)) {
+                        inputs.add(base + slimefunItem);
+                    }
+                }
+
+                World world = context.getPlayer().getWorld();
+                for (Material material : Utils.MATERIALS.values()) {
+                    String name = material.name();
+                    if (material.isEnabledByFeature(world) && name.startsWith(current)) {
+                        inputs.add(base + name);
+                    }
+                }
+            }
+
+            return inputs;
+        }
+
+        private Collection<String> generateBaseInputs(String input, World world) {
+            List<String> inputs = new ArrayList<>();
+            for (String slimefunItem : Utils.SLIMEFUN_ITEMS) {
+                inputs.add(input + slimefunItem + ",");
+            }
+
+            for (Material material : Utils.MATERIALS.values()) {
+                if (material.isEnabledByFeature(world)) {
+                    inputs.add(input + material.name() + ",");
+                }
+            }
+            return inputs;
+        }
+
+        @Override
+        public InputsFlag ofValue(String value) {
+            String[] segments = value.substring(1, value.length() - 1).split(",");
+            List<ItemStack> inputs = new ArrayList<>();
+            for (String input : segments) {
+                input = input.toUpperCase(Locale.ROOT);
+                SlimefunItem slimefunItem = SlimefunItem.getById(input);
+                Material material = Utils.MATERIALS.get(input);
+                if (slimefunItem != null) {
+                    inputs.add(new CustomItemStack(slimefunItem.getItem(), slimefunItem.getItem().getMaxStackSize()));
+                } else if (material != null) {
+                    inputs.add(new ItemStack(material, material.getMaxStackSize()));
+                }
+            }
+            return (InputsFlag) new InputsFlag().setValue(inputs);
+        }
+    }
+}

--- a/src/main/java/dev/j3fftw/worldeditslimefun/commands/flags/CommandFlags.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/commands/flags/CommandFlags.java
@@ -83,7 +83,7 @@ public class CommandFlags {
             BlockMenu menu = BlockStorage.getInventory(block);
             int[] slots = menu.getPreset().getSlotsAccessedByItemTransport(ItemTransportFlow.INSERT);
             for (ItemStack input : this.value) {
-                if (menu.pushItem(input, slots) != null) {
+                if (menu.pushItem(new ItemStack(input), slots) != null) {
                     break;
                 }
             }

--- a/src/main/java/dev/j3fftw/worldeditslimefun/slimefun/Items.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/slimefun/Items.java
@@ -12,7 +12,7 @@ import org.bukkit.inventory.ItemStack;
 
 public class Items {
     public static void init(WorldEditSlimefun plugin) {
-        final ItemGroup WESF_GROUP = new ItemGroup(
+        ItemGroup WESF_GROUP = new ItemGroup(
                 new NamespacedKey(plugin, "world_edit_slimefun"),
                 new CustomItemStack(Material.STONE_AXE, "&fWorld Edit Slimefun (Dummy Group)")
         );

--- a/src/main/java/dev/j3fftw/worldeditslimefun/slimefun/Items.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/slimefun/Items.java
@@ -12,7 +12,11 @@ import org.bukkit.inventory.ItemStack;
 
 public class Items {
     public static void init(WorldEditSlimefun plugin) {
-        final ItemGroup WESF_GROUP = new ItemGroup(new NamespacedKey(plugin, "world_edit_slimefun"), new CustomItemStack(Material.STONE_AXE, "&fWorld Edit Slimefun (Dummy Group)"));
+        final ItemGroup WESF_GROUP = new ItemGroup(
+                new NamespacedKey(plugin, "world_edit_slimefun"),
+                new CustomItemStack(Material.STONE_AXE, "&fWorld Edit Slimefun (Dummy Group)")
+        );
+
         new SlimefunItem(
                 WESF_GROUP,
                 new SlimefunItemStack(

--- a/src/main/java/dev/j3fftw/worldeditslimefun/slimefun/Items.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/slimefun/Items.java
@@ -1,0 +1,29 @@
+package dev.j3fftw.worldeditslimefun.slimefun;
+
+import dev.j3fftw.worldeditslimefun.WorldEditSlimefun;
+import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.items.CustomItemStack;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.ItemStack;
+
+public class Items {
+    public static void init(WorldEditSlimefun plugin) {
+        final ItemGroup WESF_GROUP = new ItemGroup(new NamespacedKey(plugin, "world_edit_slimefun"), new CustomItemStack(Material.STONE_AXE, "&fWorld Edit Slimefun (Dummy Group)"));
+        new SlimefunItem(
+                WESF_GROUP,
+                new SlimefunItemStack(
+                        "WESF_WAND",
+                        Material.STONE_AXE,
+                        "&f(WESF) Selection Wand",
+                        "&fLeft Click to select position 1",
+                        "&fRight Click to select position 2"
+                ),
+                RecipeType.NULL,
+                new ItemStack[9]
+        ).register(plugin);
+    }
+}

--- a/src/main/java/dev/j3fftw/worldeditslimefun/slimefun/WandListener.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/slimefun/WandListener.java
@@ -2,8 +2,12 @@ package dev.j3fftw.worldeditslimefun.slimefun;
 
 import dev.j3fftw.worldeditslimefun.utils.PositionManager;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.blocks.BlockPosition;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.protection.Interaction;
+import org.bukkit.ChatColor;
 import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -12,26 +16,35 @@ import org.bukkit.event.player.PlayerInteractEvent;
 
 public class WandListener implements Listener {
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onPlayerInteract(PlayerInteractEvent event) {
         SlimefunItem slimefunItem = SlimefunItem.getByItem(event.getItem());
         if (slimefunItem == null || !slimefunItem.getId().equals("WESF_WAND")) {
             return;
         }
 
-        event.setCancelled(true);
-        
         Block block = event.getClickedBlock();
         if (block == null) {
             return;
         }
 
+        Player player = event.getPlayer();
+        if (!Slimefun.getProtectionManager().hasPermission(player, block, Interaction.PLACE_BLOCK)
+                || !Slimefun.getProtectionManager().hasPermission(player, block, Interaction.BREAK_BLOCK)
+                || !Slimefun.getProtectionManager().hasPermission(player, block, Interaction.INTERACT_BLOCK)
+                || !player.hasPermission("wesf.admin")) {
+            player.sendMessage(ChatColor.RED + "You don't have permission!");
+            return;
+        }
+
+        event.setCancelled(true);
+
         Action action = event.getAction();
         BlockPosition position = new BlockPosition(block);
         if (action == Action.LEFT_CLICK_BLOCK) {
-            PositionManager.addPositionOne(event.getPlayer(), position);
+            PositionManager.addPositionOne(player, position);
         } else if (action == Action.RIGHT_CLICK_BLOCK) {
-            PositionManager.addPositionTwo(event.getPlayer(), position);
+            PositionManager.addPositionTwo(player, position);
         }
     }
 }

--- a/src/main/java/dev/j3fftw/worldeditslimefun/slimefun/WandListener.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/slimefun/WandListener.java
@@ -2,6 +2,8 @@ package dev.j3fftw.worldeditslimefun.slimefun;
 
 import dev.j3fftw.worldeditslimefun.utils.PositionManager;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.blocks.BlockPosition;
+import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -12,18 +14,24 @@ public class WandListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onPlayerInteract(PlayerInteractEvent event) {
-        final SlimefunItem slimefunItem = SlimefunItem.getByItem(event.getItem());
+        SlimefunItem slimefunItem = SlimefunItem.getByItem(event.getItem());
         if (slimefunItem == null || !slimefunItem.getId().equals("WESF_WAND")) {
             return;
         }
 
         event.setCancelled(true);
+        
+        Block block = event.getClickedBlock();
+        if (block == null) {
+            return;
+        }
 
-        final Action action = event.getAction();
+        Action action = event.getAction();
+        BlockPosition position = new BlockPosition(block);
         if (action == Action.LEFT_CLICK_BLOCK) {
-            PositionManager.addPositionOne(event.getPlayer());
+            PositionManager.addPositionOne(event.getPlayer(), position);
         } else if (action == Action.RIGHT_CLICK_BLOCK) {
-            PositionManager.addPositionTwo(event.getPlayer());
+            PositionManager.addPositionTwo(event.getPlayer(), position);
         }
     }
 }

--- a/src/main/java/dev/j3fftw/worldeditslimefun/slimefun/WandListener.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/slimefun/WandListener.java
@@ -1,0 +1,27 @@
+package dev.j3fftw.worldeditslimefun.slimefun;
+
+import dev.j3fftw.worldeditslimefun.WorldEditSlimefun;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+
+public class WandListener implements Listener {
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onPlayerInteract(PlayerInteractEvent event) {
+        final SlimefunItem slimefunItem = SlimefunItem.getByItem(event.getItem());
+        if (slimefunItem == null || !slimefunItem.getId().equals("WESF_WAND")) {
+            return;
+        }
+
+        event.setCancelled(true);
+        final Action action = event.getAction();
+        if (action == Action.LEFT_CLICK_BLOCK) {
+            WorldEditSlimefun.addPositionOne(event.getPlayer());
+        } else if (action == Action.RIGHT_CLICK_BLOCK) {
+            WorldEditSlimefun.addPositionTwo(event.getPlayer());
+        }
+    }
+}

--- a/src/main/java/dev/j3fftw/worldeditslimefun/slimefun/WandListener.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/slimefun/WandListener.java
@@ -1,6 +1,6 @@
 package dev.j3fftw.worldeditslimefun.slimefun;
 
-import dev.j3fftw.worldeditslimefun.WorldEditSlimefun;
+import dev.j3fftw.worldeditslimefun.utils.PositionManager;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -9,6 +9,7 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
 
 public class WandListener implements Listener {
+
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onPlayerInteract(PlayerInteractEvent event) {
         final SlimefunItem slimefunItem = SlimefunItem.getByItem(event.getItem());
@@ -17,11 +18,12 @@ public class WandListener implements Listener {
         }
 
         event.setCancelled(true);
+
         final Action action = event.getAction();
         if (action == Action.LEFT_CLICK_BLOCK) {
-            WorldEditSlimefun.addPositionOne(event.getPlayer());
+            PositionManager.addPositionOne(event.getPlayer());
         } else if (action == Action.RIGHT_CLICK_BLOCK) {
-            WorldEditSlimefun.addPositionTwo(event.getPlayer());
+            PositionManager.addPositionTwo(event.getPlayer());
         }
     }
 }

--- a/src/main/java/dev/j3fftw/worldeditslimefun/tasks/AbstractTask.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/tasks/AbstractTask.java
@@ -1,0 +1,58 @@
+package dev.j3fftw.worldeditslimefun.tasks;
+
+import dev.j3fftw.worldeditslimefun.WorldEditSlimefun;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.blocks.BlockPosition;
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
+import org.bukkit.block.Block;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public abstract class AbstractTask extends BukkitRunnable {
+    protected final SlimefunItem sfItem;
+    protected final Set<BlockPosition> blocks = new HashSet<>();
+    protected int timeout = 20 * 60 * 5; // Default timeout of 5 minutes
+    protected int ticks = 0;
+
+    public AbstractTask(SlimefunItem sfItem) {
+        this.sfItem = sfItem;
+    }
+
+    @Override
+    public final void run() {
+        if (blocks.isEmpty()) {
+            cancel();
+            return;
+        }
+
+        if (ticks >= timeout) {
+            cancel();
+            return;
+        }
+
+        for (BlockPosition position : new HashSet<>(blocks)) {
+            Block block = position.getBlock();
+            if (!BlockStorage.check(block, sfItem.getId())) {
+                blocks.remove(position);
+                continue;
+            }
+            runTask(block);
+        }
+        ticks += 10;
+    }
+
+    public abstract void runTask(Block block);
+
+    public void addBlock(Block block) {
+        if (ticks == 0 && blocks.isEmpty()) {
+            runTaskTimer(WorldEditSlimefun.getInstance(), 20, 10);
+        }
+        blocks.add(new BlockPosition(block));
+    }
+
+    public void setTimeout(int timeout) {
+        this.timeout = timeout;
+    }
+}

--- a/src/main/java/dev/j3fftw/worldeditslimefun/tasks/RefillInputsTask.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/tasks/RefillInputsTask.java
@@ -1,0 +1,43 @@
+package dev.j3fftw.worldeditslimefun.tasks;
+
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
+import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
+import me.mrCookieSlime.Slimefun.api.inventory.BlockMenuPreset;
+import me.mrCookieSlime.Slimefun.api.item_transport.ItemTransportFlow;
+import org.bukkit.block.Block;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RefillInputsTask extends AbstractTask {
+
+    protected final int[] slots;
+    protected List<ItemStack> inputs = new ArrayList<>();
+
+    public RefillInputsTask(SlimefunItem sfItem) {
+        super(sfItem);
+
+        BlockMenuPreset preset = Slimefun.getRegistry().getMenuPresets().get(sfItem.getId());
+        this.slots = preset == null ? new int[0] : preset.getSlotsAccessedByItemTransport(ItemTransportFlow.INSERT);
+    }
+
+    @Override
+    public void runTask(Block block) {
+        BlockMenu menu = BlockStorage.getInventory(block);
+        if (menu == null) {
+            return;
+        }
+
+        for (ItemStack itemStack : this.inputs) {
+            menu.pushItem(itemStack, this.slots);
+        }
+    }
+
+
+    public void setInputs(List<ItemStack> inputs) {
+        this.inputs = inputs;
+    }
+}

--- a/src/main/java/dev/j3fftw/worldeditslimefun/tasks/RefillInputsTask.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/tasks/RefillInputsTask.java
@@ -32,7 +32,7 @@ public class RefillInputsTask extends AbstractTask {
         }
 
         for (ItemStack itemStack : this.inputs) {
-            menu.pushItem(itemStack, this.slots);
+            menu.pushItem(new ItemStack(itemStack), this.slots);
         }
     }
 

--- a/src/main/java/dev/j3fftw/worldeditslimefun/tasks/VoidOutputsTask.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/tasks/VoidOutputsTask.java
@@ -1,0 +1,34 @@
+package dev.j3fftw.worldeditslimefun.tasks;
+
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
+import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
+import me.mrCookieSlime.Slimefun.api.inventory.BlockMenuPreset;
+import me.mrCookieSlime.Slimefun.api.item_transport.ItemTransportFlow;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.inventory.ItemStack;
+
+public class VoidOutputsTask extends AbstractTask {
+    private final int[] slots;
+
+    public VoidOutputsTask(SlimefunItem sfItem) {
+        super(sfItem);
+
+        BlockMenuPreset preset = Slimefun.getRegistry().getMenuPresets().get(sfItem.getId());
+        this.slots = preset == null ? new int[0] : preset.getSlotsAccessedByItemTransport(ItemTransportFlow.WITHDRAW);
+    }
+
+    @Override
+    public void runTask(Block block) {
+        BlockMenu menu = BlockStorage.getInventory(block);
+        if (menu == null) {
+            return;
+        }
+
+        for (int slot : this.slots) {
+            menu.replaceExistingItem(slot, new ItemStack(Material.AIR));
+        }
+    }
+}

--- a/src/main/java/dev/j3fftw/worldeditslimefun/utils/PositionManager.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/utils/PositionManager.java
@@ -1,0 +1,49 @@
+package dev.j3fftw.worldeditslimefun.utils;
+
+import io.github.thebusybiscuit.slimefun4.libraries.dough.blocks.BlockPosition;
+import org.bukkit.entity.Player;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class PositionManager {
+
+    @Nonnull
+    private static final Map<UUID, BlockPosition> STORED_POSITION_ONE = new HashMap<>();
+    @Nonnull
+    private static final Map<UUID, BlockPosition> STORED_POSITION_TWO = new HashMap<>();
+
+    public static void addPositionOne(@Nonnull Player player) {
+        addPositionOne(player, new BlockPosition(player.getLocation()));
+    }
+
+    @ParametersAreNonnullByDefault
+    public static void addPositionOne(Player player, BlockPosition position) {
+        STORED_POSITION_ONE.put(player.getUniqueId(), position);
+        player.sendMessage("Set position 1 to " + Utils.beautifyBlockPosition(position));
+    }
+
+    public static void addPositionTwo(@Nonnull Player player) {
+        addPositionTwo(player, new BlockPosition(player.getLocation()));
+    }
+
+    @ParametersAreNonnullByDefault
+    public static void addPositionTwo(Player player, BlockPosition position) {
+        STORED_POSITION_TWO.put(player.getUniqueId(), position);
+        player.sendMessage("Set position 2 to " + Utils.beautifyBlockPosition(position));
+    }
+
+    @Nullable
+    public static BlockPosition getPositionOne(@Nonnull Player player) {
+        return STORED_POSITION_ONE.get(player.getUniqueId());
+    }
+
+    @Nullable
+    public static BlockPosition getPositionTwo(@Nonnull Player player) {
+        return STORED_POSITION_TWO.get(player.getUniqueId());
+    }
+}

--- a/src/main/java/dev/j3fftw/worldeditslimefun/utils/Utils.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/utils/Utils.java
@@ -1,0 +1,52 @@
+package dev.j3fftw.worldeditslimefun.utils;
+
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import io.github.thebusybiscuit.slimefun4.implementation.items.blocks.UnplaceableBlock;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.blocks.BlockPosition;
+import org.bukkit.Material;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Utils {
+
+    public static final List<String> SLIMEFUN_BLOCKS = new ArrayList<>();
+    public static final List<String> SLIMEFUN_ITEMS = new ArrayList<>();
+    public static final Map<String, Material> MATERIALS = new HashMap<>();
+
+    static {
+        for (SlimefunItem item : Slimefun.getRegistry().getEnabledSlimefunItems()) {
+            if (!(item instanceof UnplaceableBlock) && item.getItem().getType().isBlock()) {
+                SLIMEFUN_BLOCKS.add(item.getId());
+            }
+            SLIMEFUN_ITEMS.add(item.getId());
+        }
+
+        for (Material material : Material.values()) {
+            if (!material.isEmpty() && !material.isLegacy()) {
+                MATERIALS.put(material.name(), material);
+            }
+        }
+
+        SLIMEFUN_BLOCKS.sort(Comparator.naturalOrder());
+        SLIMEFUN_ITEMS.sort(Comparator.naturalOrder());
+    }
+
+    public static boolean isValidMaterial(String material) {
+        return MATERIALS.containsKey(material);
+    }
+
+    public static Material getMaterial(String material) {
+        return MATERIALS.get(material);
+    }
+
+    @Nonnull
+    public static String beautifyBlockPosition(@Nonnull BlockPosition position) {
+        return "%s, %s, %s (%s)".formatted(position.getX(), position.getY(), position.getZ(), position.getWorld().getName());
+    }
+}

--- a/src/main/java/dev/j3fftw/worldeditslimefun/utils/Utils.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/utils/Utils.java
@@ -37,14 +37,6 @@ public class Utils {
         SLIMEFUN_ITEMS.sort(Comparator.naturalOrder());
     }
 
-    public static boolean isValidMaterial(String material) {
-        return MATERIALS.containsKey(material);
-    }
-
-    public static Material getMaterial(String material) {
-        return MATERIALS.get(material);
-    }
-
     @Nonnull
     public static String beautifyBlockPosition(@Nonnull BlockPosition position) {
         return "%s, %s, %s (%s)".formatted(position.getX(), position.getY(), position.getZ(), position.getWorld().getName());


### PR DESCRIPTION
This PR does a LARGE amount of things, I will do my best to cover them all here.

## To Do
- Update the Readme (I need yall's feedback cause idk how to format it with the flags system)
- More extensive testing? (I've done quite a lot but maybe I should do more)

## Changes (Small ones)
-  Refactored the main class
   - Jeff wanted me to clean up this class so I delegated most of the things to relevant classes
   - Just makes it cleaner and such
-  Added a Selection wand
   - Added `Items` where any slimefun items can be registered on `Items#init`, currently only used for the wand
   - The wand and the item group are hidden
   - obtainable with `/wesf wand`
   - Added `WandListener` used to detect when a player uses the wand
- Added `PositionManager`
  - this class was added in the refactor of the main class
  - just tracks players and their stored positions   
- Added `Utils`
  - Also added in the refactor of the main class
  - Just has misc things used in the plugin
  
## Command Changes
There was some major changes made here
### WorldEditSlimefunCommands Changes
- New annotations
  - Added a suppressor for unused warnings (because of how commands work)
  - Added the `@CommandPermission("wesf.admin")` annotation, as it will automatically apply to all commands instead of manually adding to each subcommand
- Added `WorldEditSlimefunCommands#init`
  - Registers any completions, contexts, and commands to ACF
- Added a wand sub command
- Refactored to use the new `PositionManager` 
- Added `WorldEditSlimefunCommands#loopThroughSelection`
  - This method is used to reduce duplicated code, it loops through the selection and calls the runnable provided
  - updated the paste and clear command to use this method
- Slightly tweaked clear command parameters
  - default callEvent to false
  - instead of registering a completion for booleans just supply true and false directly
- Largely tweaked the paste command
  - added some more warnings when invalid pastes are attempted
  - added command flags (see next section)
  - clear any blockstorage on the blocks being pasted (fixes some weird behavior)

### CommandFlags
At the request of Jeff I have made a Command flag system, this is modular and can be easily updated in the future to add more features
- Added `CommandFlag` this abstract class accepts a type parameter for its value, ie, EnergyFlag stores a boolean, true to add, false to not
- Added `CommandFlags` this class stores all actual flags & is the "brains" behind most of the operation
  - Any `CommandFlag` implementations are stored in the `FLAG_TYPES` map, where the flag is mapped to the default instance of a flag
  - Currently the 5 types are "--energy", "--inputs", "--refill_inputs_task", "--void_outputs_task", and "--timeout"
- Added a command completion "@command_flags" this completion is responsible for displaying the flags and helping complete the values for the player in the command line

## Other
if you have any specific questions about implementation lmk