### PR TITLE
[Chore] Use Slimefun Registry Event & Hide Item Group

### DIFF
--- a/src/main/java/dev/j3fftw/worldeditslimefun/WorldEditSlimefun.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/WorldEditSlimefun.java
@@ -1,12 +1,14 @@
 package dev.j3fftw.worldeditslimefun;
 
 import dev.j3fftw.worldeditslimefun.commands.WorldEditSlimefunCommands;
+import dev.j3fftw.worldeditslimefun.listeners.RegistryListener;
 import dev.j3fftw.worldeditslimefun.slimefun.Items;
-import dev.j3fftw.worldeditslimefun.slimefun.WandListener;
+import dev.j3fftw.worldeditslimefun.listeners.WandListener;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.updater.BlobBuildUpdater;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.Bukkit;
+import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import javax.annotation.Nonnull;
@@ -32,7 +34,10 @@ public final class WorldEditSlimefun extends JavaPlugin implements SlimefunAddon
 
         Items.init(this);
         WorldEditSlimefunCommands.init(this);
-        Bukkit.getPluginManager().registerEvents(new WandListener(), this);
+
+        PluginManager manager = Bukkit.getPluginManager();
+        manager.registerEvents(new WandListener(), this);
+        manager.registerEvents(new RegistryListener(), this);
     }
 
     @Override

--- a/src/main/java/dev/j3fftw/worldeditslimefun/listeners/RegistryListener.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/listeners/RegistryListener.java
@@ -1,0 +1,14 @@
+package dev.j3fftw.worldeditslimefun.listeners;
+
+import dev.j3fftw.worldeditslimefun.utils.Utils;
+import io.github.thebusybiscuit.slimefun4.api.events.SlimefunItemRegistryFinalizedEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+public class RegistryListener implements Listener {
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onRegistryInitialized(SlimefunItemRegistryFinalizedEvent event) {
+        Utils.init();
+    }
+}

--- a/src/main/java/dev/j3fftw/worldeditslimefun/listeners/WandListener.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/listeners/WandListener.java
@@ -1,4 +1,4 @@
-package dev.j3fftw.worldeditslimefun.slimefun;
+package dev.j3fftw.worldeditslimefun.listeners;
 
 import dev.j3fftw.worldeditslimefun.utils.PositionManager;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;

--- a/src/main/java/dev/j3fftw/worldeditslimefun/slimefun/Items.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/slimefun/Items.java
@@ -8,14 +8,22 @@ import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.items.CustomItemStack;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+
+import javax.annotation.Nonnull;
 
 public class Items {
     public static void init(WorldEditSlimefun plugin) {
         ItemGroup WESF_GROUP = new ItemGroup(
                 new NamespacedKey(plugin, "world_edit_slimefun"),
-                new CustomItemStack(Material.STONE_AXE, "&fWorld Edit Slimefun (Dummy Group)")
-        );
+                new CustomItemStack(Material.STONE_AXE, "&fWorld Edit Slimefun")
+        ) {
+            @Override
+            public boolean isVisible(@Nonnull Player ignored) {
+                return false;
+            }
+        };
 
         new SlimefunItem(
                 WESF_GROUP,

--- a/src/main/java/dev/j3fftw/worldeditslimefun/utils/Utils.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/utils/Utils.java
@@ -19,7 +19,7 @@ public class Utils {
     public static final List<String> SLIMEFUN_ITEMS = new ArrayList<>();
     public static final Map<String, Material> MATERIALS = new HashMap<>();
 
-    static {
+    public static void init() {
         for (SlimefunItem item : Slimefun.getRegistry().getEnabledSlimefunItems()) {
             if (!(item instanceof UnplaceableBlock) && item.getItem().getType().isBlock()) {
                 SLIMEFUN_BLOCKS.add(item.getId());


### PR DESCRIPTION
Like the title says, this just switches WESF to use the registry event when it builds the lists in utils, currently we don't which can lead to some addons not appearing in the autocomplete of the command.

Then also just hiding the item group that way its only visible in cheat mode