### PR TITLE
[Api] Expand Flag Api

### DIFF
--- a/src/main/java/dev/j3fftw/worldeditslimefun/commands/WorldEditSlimefunCommands.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/commands/WorldEditSlimefunCommands.java
@@ -50,7 +50,7 @@ public class WorldEditSlimefunCommands extends BaseCommand {
         completions.registerStaticCompletion("slimefun_blocks", Utils.SLIMEFUN_BLOCKS);
         completions.registerAsyncCompletion("command_flags", context -> {
             List<String> args = new ArrayList<>(Arrays.asList(context.getContextValueByName(String[].class, "commandFlags")));
-            List<String> availableFlags = new ArrayList<>(CommandFlags.FLAG_TYPES.keySet());
+            List<String> availableFlags = new ArrayList<>(CommandFlags.getFlagTypes().keySet());
             availableFlags.removeAll(args);
 
             if (args.isEmpty()) {
@@ -63,8 +63,8 @@ public class WorldEditSlimefunCommands extends BaseCommand {
             }
 
             String lastArg = args.get(args.size() - 1);
-            if (CommandFlags.FLAG_TYPES.containsKey(lastArg)) {
-                return CommandFlags.FLAG_TYPES.get(lastArg).getTabSuggestions(context);
+            if (CommandFlags.getFlagTypes().containsKey(lastArg)) {
+                return CommandFlags.getFlagTypes().get(lastArg).getTabSuggestions(context);
             }
 
             if (args.size() % 2 == 0) {
@@ -140,7 +140,7 @@ public class WorldEditSlimefunCommands extends BaseCommand {
             });
 
             for (CommandFlag<?> flag : flags) {
-                flag.apply(flags, sfItem, block);
+                flag.apply(player, flags, sfItem, block);
             }
         });
         long time = System.currentTimeMillis() - start;

--- a/src/main/java/dev/j3fftw/worldeditslimefun/commands/flags/CommandFlag.java
+++ b/src/main/java/dev/j3fftw/worldeditslimefun/commands/flags/CommandFlag.java
@@ -3,6 +3,7 @@ package dev.j3fftw.worldeditslimefun.commands.flags;
 import co.aikar.commands.BukkitCommandCompletionContext;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
 
 import java.util.Collection;
 import java.util.List;
@@ -19,7 +20,7 @@ public abstract class CommandFlag<T> {
         return value;
     }
 
-    public abstract void apply(List<CommandFlag<?>> flags, SlimefunItem sfItem, Block block);
+    public abstract void apply(Player player, List<CommandFlag<?>> flags, SlimefunItem sfItem, Block block);
     public abstract boolean canApply(SlimefunItem sfItem);
     public abstract Collection<String> getTabSuggestions(BukkitCommandCompletionContext context);
 


### PR DESCRIPTION
## Description
Expands the flags api to allow for other plugins to hook in and add more command flags, the use case atm is testing blockstorage shenanigans which will use flags that wouldn't make sense to have in the plugin itself

## Changes
- Added `player` as the first parameter for `CommandFlag#apply`, the value being the player who executed the command
- Changed `CommandFlags#FLAG_TYPES` to be private and modifiable
  - Added `CommandFlags#getFlagTypes` which returns an unmodifiable copy
- Added `CommandFlags#addFlagType` which will register a type with the given parameters
- Added javadocs to the api methods of `CommandFlags`